### PR TITLE
Fix undefined variable warnings in OpenSCAD 2019.05

### DIFF
--- a/src/main/scad/puzzlecad-tests.scad
+++ b/src/main/scad/puzzlecad-tests.scad
@@ -15,61 +15,74 @@ include <puzzlecad.scad>
 // Burr piece with different inset on each dimension.
 *burr_piece(["xx|.x", ".x|.."], $burr_inset = [0, 1.5, 3], $burr_bevel = 1.5);
 
+// Simple connector test:
+*burr_plate([
+    ["x{connect=mz+,clabel=Lx+}"]
+]);
+
 // Male connector test:
 *burr_plate([
-    "x{connect=mz+,clabel=Lx+}",
-    "x{connect=mz+,clabel=Ly-}",
-    "x{connect=mz+,clabel=Lx-}",
-    "x{connect=mz+,clabel=Ly+}",
-    "x{connect=mz-,clabel=Lx+}",
-    "x{connect=mz-,clabel=Ly-}",
-    "x{connect=mz-,clabel=Lx-}",
-    "x{connect=mz-,clabel=Ly+}",
-    "x{connect=my+,clabel=Lx+}|.",
-    "x{connect=my+,clabel=Lz-}|.",
-    "x{connect=my+,clabel=Lx-}|.",
-    "x{connect=my+,clabel=Lz+}|.",
-    "x{connect=my-,clabel=Lx+}",
-    "x{connect=my-,clabel=Lz-}",
-    "x{connect=my-,clabel=Lx-}",
-    "x{connect=my-,clabel=Lz+}",
-    "x{connect=mx+,clabel=Lz+}.",
-    "x{connect=mx+,clabel=Ly-}.",
-    "x{connect=mx+,clabel=Lz-}.",
-    "x{connect=mx+,clabel=Ly+}.",
-    ".x{connect=mx-,clabel=Lz+}",
-    ".x{connect=mx-,clabel=Ly-}",
-    ".x{connect=mx-,clabel=Lz-}",
-    ".x{connect=mx-,clabel=Ly+}"    
+    ["x{connect=mz+,clabel=Lx+}"],
+    ["x{connect=mz+,clabel=Ly-}"],
+    ["x{connect=mz+,clabel=Lx-}"],
+    ["x{connect=mz+,clabel=Ly+}"],
+    ["x{connect=mz-,clabel=Lx+}"],
+    ["x{connect=mz-,clabel=Ly-}"],
+    ["x{connect=mz-,clabel=Lx-}"],
+    ["x{connect=mz-,clabel=Ly+}"],
+    ["x{connect=my+,clabel=Lx+}|."],
+    ["x{connect=my+,clabel=Lz-}|."],
+    ["x{connect=my+,clabel=Lx-}|."],
+    ["x{connect=my+,clabel=Lz+}|."],
+    ["x{connect=my-,clabel=Lx+}"],
+    ["x{connect=my-,clabel=Lz-}"],
+    ["x{connect=my-,clabel=Lx-}"],
+    ["x{connect=my-,clabel=Lz+}"],
+    ["x{connect=mx+,clabel=Lz+}."],
+    ["x{connect=mx+,clabel=Ly-}."],
+    ["x{connect=mx+,clabel=Lz-}."],
+    ["x{connect=mx+,clabel=Ly+}."],
+    [".x{connect=mx-,clabel=Lz+}"],
+    [".x{connect=mx-,clabel=Ly-}"],
+    [".x{connect=mx-,clabel=Lz-}"],
+    [".x{connect=mx-,clabel=Ly+}"]    
 ], $plate_width = 75, $joint_inset = 0);
+
 // Female connector test:
 *burr_plate([
-    "x{connect=fz+,clabel=Lx+}",
-    "x{connect=fz+,clabel=Ly-}",
-    "x{connect=fz+,clabel=Lx-}",
-    "x{connect=fz+,clabel=Ly+}",
-    "x{connect=fz-,clabel=Lx+}",
-    "x{connect=fz-,clabel=Ly-}",
-    "x{connect=fz-,clabel=Lx-}",
-    "x{connect=fz-,clabel=Ly+}",
-    "x{connect=fy+,clabel=Lx+}",
-    "x{connect=fy+,clabel=Lz-}",
-    "x{connect=fy+,clabel=Lx-}",
-    "x{connect=fy+,clabel=Lz+}",
-    "x{connect=fy-,clabel=Lx+}",
-    "x{connect=fy-,clabel=Lz-}",
-    "x{connect=fy-,clabel=Lx-}",
-    "x{connect=fy-,clabel=Lz+}",
-    "x{connect=fx+,clabel=Lz+}",
-    "x{connect=fx+,clabel=Ly-}",
-    "x{connect=fx+,clabel=Lz-}",
-    "x{connect=fx+,clabel=Ly+}",
-    "x{connect=fx-,clabel=Lz+}",
-    "x{connect=fx-,clabel=Ly-}",
-    "x{connect=fx-,clabel=Lz-}",
-    "x{connect=fx-,clabel=Ly+}"    
+    ["x{connect=fz+,clabel=Lx+}"],
+    ["x{connect=fz+,clabel=Ly-}"],
+    ["x{connect=fz+,clabel=Lx-}"],
+    ["x{connect=fz+,clabel=Ly+}"],
+    ["x{connect=fz-,clabel=Lx+}"],
+    ["x{connect=fz-,clabel=Ly-}"],
+    ["x{connect=fz-,clabel=Lx-}"],
+    ["x{connect=fz-,clabel=Ly+}"],
+    ["x{connect=fy+,clabel=Lx+}"],
+    ["x{connect=fy+,clabel=Lz-}"],
+    ["x{connect=fy+,clabel=Lx-}"],
+    ["x{connect=fy+,clabel=Lz+}"],
+    ["x{connect=fy-,clabel=Lx+}"],
+    ["x{connect=fy-,clabel=Lz-}"],
+    ["x{connect=fy-,clabel=Lx-}"],
+    ["x{connect=fy-,clabel=Lz+}"],
+    ["x{connect=fx+,clabel=Lz+}"],
+    ["x{connect=fx+,clabel=Ly-}"],
+    ["x{connect=fx+,clabel=Lz-}"],
+    ["x{connect=fx+,clabel=Ly+}"],
+    ["x{connect=fx-,clabel=Lz+}"],
+    ["x{connect=fx-,clabel=Ly-}"],
+    ["x{connect=fx-,clabel=Lz-}"],
+    ["x{connect=fx-,clabel=Ly+}"]
 ], $plate_width = 75, $joint_inset = 0);
+
+// This particular example caused some manifold-related rendering grief
+// with OpenSCAD 2019.05 (the issue has been fixed, but keeping the test
+// here just in case):
+*burr_piece(["xxx{connect=mz+}|x.."]);
+
 *burr_piece("x{connect=fz+,clabel=Ay-}");
+
 *burr_plate([["x{connect=my-}...|x{connect=fz+}x{connect=mz+}x.|...."]]);
-*burr_piece(975, label=true);
-*burr_plate(obscure_notchables);
+
+*burr_piece(975, label = "975");

--- a/src/main/scad/puzzlecad.scad
+++ b/src/main/scad/puzzlecad.scad
@@ -20,6 +20,13 @@ $plate_depth = 180;
 $plate_sep = 6;
 $joint_inset = 0;
 
+// These parameters are optional and can be used to increase
+// the amount of beveling on outer edges of burr pieces.
+
+$burr_outer_x_bevel = undef;
+$burr_outer_y_bevel = undef;
+$burr_outer_z_bevel = undef;
+
 /* Main module for rendering a burr piece.
  * "burr_spec" can be any of the following:
  *    - a stick number: 975

--- a/src/main/scad/puzzlecad.scad
+++ b/src/main/scad/puzzlecad.scad
@@ -710,6 +710,7 @@ all_letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 /***** Vector manipulation *****/
 
 function zyx_to_xyz(burr) =
+    burr == [] ? [] :
     [ for (x = [0:len(burr[0][0])-1])
         [ for (y = [0:len(burr[0])-1])
             [ for (z = [0:len(burr)-1])

--- a/src/main/scad/puzzlecad.scad
+++ b/src/main/scad/puzzlecad.scad
@@ -188,7 +188,7 @@ module burr_piece_base(burr_spec) {
                                 translate(cw(scale_vec / 2, [i,j,k]) + iota_vec)
                                 translate(-[x_adj*i, y_adj*j, z_adj*k] / sqrt(2) + cw([bevel_scale, bevel_scale, bevel_scale] / sqrt(2) / 2 - inset_vec, [i,j,k]))
                                 scale(bevel_scale / sqrt(2) / 2)
-                                exterior_corner_bevel([i,j,k]);
+                                exterior_corner_bevel_cutout([i,j,k]);
                             }
                         }
                     } else {
@@ -198,7 +198,7 @@ module burr_piece_base(burr_spec) {
                             translate(cw(scale_vec / 2, [i,j,k]))
                             translate(cw(inset_vec + bevel_vec / sqrt(2) / 2, [i,j,-k]))
                             scale(bevel_vec / sqrt(2) / 2)
-                            interior_corner_bevel([-i,-j,k]);
+                            interior_corner_bevel_cutout([-i,-j,k]);
                         }
                         // Interior corner bevel on the xz plane.
                         if (burr[x+i][y][z] == 1 && burr[x][y][z+k] == 1 &&
@@ -206,7 +206,7 @@ module burr_piece_base(burr_spec) {
                             translate(cw(scale_vec / 2, [i,j,k]))
                             translate(cw(inset_vec + bevel_vec / sqrt(2) / 2, [i,-j,k]))
                             scale(bevel_vec / sqrt(2) / 2)
-                            interior_corner_bevel([-i,j,-k]);
+                            interior_corner_bevel_cutout([-i,j,-k]);
                         }
                         // Interior corner bevel on the yz plane.
                         if (burr[x][y+j][z] == 1 && burr[x][y][z+k] == 1 &&
@@ -214,7 +214,7 @@ module burr_piece_base(burr_spec) {
                             translate(cw(scale_vec / 2, [i,j,k]))
                             translate(cw(inset_vec + bevel_vec / sqrt(2) / 2, [-i,j,k]))
                             scale(bevel_vec / sqrt(2) / 2)
-                            interior_corner_bevel([i,-j,-k]);
+                            interior_corner_bevel_cutout([i,-j,-k]);
                         }
                     }
                 }
@@ -318,7 +318,7 @@ module edge_bevel_cutout(length, x_scale, y_scale, bevel, i, j) {
  * "vertex" is a vector of +-1's, such as [-1, 1, -1], specifying one of the
  * eight cube vertices for the wedge.
  */
-module interior_corner_bevel(vertex) {
+module interior_corner_bevel_cutout(vertex) {
     adj_vertex = vertex * (1 + iota * 20) + iota_vec;
     polyhedron(
         [
@@ -333,13 +333,13 @@ module interior_corner_bevel(vertex) {
 
 /* Module for rendering the negative of a cube wedge.
  */
-module exterior_corner_bevel(vertex) {
+module exterior_corner_bevel_cutout(vertex) {
     
     render(convexity = 2)
     difference() {
         translate(iota_vec)
         cube([2, 2, 2] * (1 + iota * 10), center = true);
-        interior_corner_bevel(-vertex);
+        interior_corner_bevel_cutout(-vertex);
     }
     
 }


### PR DESCRIPTION
This fixes the "undefined variable" warnings in OpenSCAD 2019.05 (which were not present in 2015.03).