### PR TITLE
Add descriptions for No Holes Barred and L-I-Vator I

### DIFF
--- a/src/main/scad/globals.yaml
+++ b/src/main/scad/globals.yaml
@@ -22,6 +22,11 @@ yavuz-demirhan-bio: |
 
     Yavuz Demirhan is one of the most prolific active designers of interlocking mechanical puzzles, with over five hundred [published designs](http://puzzlewillbeplayed.com/-/designer/Demirhan.xml), ranging from simple and bite-sized to highly complex. His designs have featured prominently at the International Puzzle Party and have been realized by some of the world's top puzzle craftsmen. Demirhan is also an accomplished woodcrafter, selling finely crafted copies of his and other designers' puzzles through his etsy shop, [Cubozone](https://www.etsy.com/shop/Cubozone).
 
+laszlo-molnar-bio: |
+    ### About the Designer
+
+    László Molnár is well-known for designing puzzles that are based on a seemingly simple idea, but are actually fiendishly difficult. In recent years, Molnár's designs have featured prominently at the International Puzzle Party, and his packing puzzle _Hat Trick_ received a Top 10 award at the 2019 IPP in Kanazawa, Japan. A Google search for "laszlo molnar puzzles" will turn up lots of information about his designs, including links to several that are commercially available.
+
 osanori-yamamoto-bio: |
     ### About the Designer
     

--- a/src/main/scad/laszlo-molnar/l-i-vator-i/molnar.l-i-vator-i.scad
+++ b/src/main/scad/laszlo-molnar/l-i-vator-i/molnar.l-i-vator-i.scad
@@ -1,21 +1,23 @@
 include <puzzlecad.scad>
 
-box_puzzle_border = 6;
-
 $burr_inset = 0.125;
 $burr_bevel = 1;
 $unit_beveled = true;
 $burr_scale = 17;
+
+box_puzzle_border = 6;
+
+// Uncomment one of the following lines to render that component.
+
+*box();
+*pieces();
+*cap();
 
 dim = $burr_scale * 3 + box_puzzle_border * 2 + $burr_inset * 2;
 height = $burr_scale * 3 + box_puzzle_border + $burr_inset * 2;
 
 mid = box_puzzle_border / 2 + 0.5;
 far = dim - mid;
-    
-*box();
-*pieces();
-*cap();
 
 module box() {
     render(convexity = 2)

--- a/src/main/scad/laszlo-molnar/l-i-vator-i/molnar.l-i-vator-i.scad
+++ b/src/main/scad/laszlo-molnar/l-i-vator-i/molnar.l-i-vator-i.scad
@@ -22,7 +22,7 @@ far = dim - mid;
 module box() {
     render(convexity = 2)
     difference() {
-        beveled_cube([dim, dim, height]);
+        beveled_cube([dim, dim, height], $burr_bevel = 0.5);
         translate([box_puzzle_border, box_puzzle_border, box_puzzle_border])
         cube([
             $burr_scale * 3 + $burr_inset * 2,
@@ -51,7 +51,7 @@ module pieces() {
 module cap() {
     render(convexity = 2)
     difference() {
-        beveled_cube([dim, dim, box_puzzle_border]);
+        beveled_cube([dim, dim, box_puzzle_border], $burr_bevel = 0.5);
         translate([box_puzzle_border, box_puzzle_border, 
         -0.01
         ])

--- a/src/main/scad/laszlo-molnar/l-i-vator-i/molnar.l-i-vator-i.yaml
+++ b/src/main/scad/laszlo-molnar/l-i-vator-i/molnar.l-i-vator-i.yaml
@@ -1,0 +1,27 @@
+thing-id: 4183212
+name: "L-I-Vator I - Packing puzzle by László Molnár"
+tags: [puzzle, 3D_puzzle]
+images: [pieces.jpg]
+targets: [box, pieces]
+description: |
+  Pack six pieces into an obstructed box.
+
+  _L-I-Vator I_ is one of a series of challenging packing puzzles by László Molnár. This one is of intermediate difficulty by the standards of Molnár's packing puzzles, which by most other standards means "quite hard". If you're up for a challenge, it will be a fun and rewarding print.
+
+  If you like this puzzle, be sure to check out its sequel, [L-I-Vator II](https://www.thingiverse.com/thing:4183224), and the other designs in our [László Molnár puzzles](https://www.thingiverse.com/asiegel/collections/laszlo-molnar-puzzles) collection.
+
+  Yu Chih Chang contributed models and photographs to this listing.
+
+  ### Printing Instructions
+
+  Print one copy each of `molnar.l-i-vator-i.box.stl`, `molnar.l-i-vator-i.cap.stl`, and `molnar.l-i-vator-i.pieces.stl`. Ideally, print the box in one filament color and the pieces in a different color. The cap may be printed in the same color as the box, or optionally in a third color.
+
+  This print uses "snap joints" so that it can be printed without supports. ${snap-joints-boilerplate}
+
+  ${box-assembly-boilerplate}
+
+  ${puzzlecad-boilerplate}
+
+  ${laszlo-molnar-bio}
+
+  Happy puzzling!

--- a/src/main/scad/laszlo-molnar/no-holes-barred/molnar.no-holes-barred.scad
+++ b/src/main/scad/laszlo-molnar/no-holes-barred/molnar.no-holes-barred.scad
@@ -20,7 +20,7 @@ height = $burr_scale * 3 + box_puzzle_border + $burr_inset;
 module box() {
     render(convexity = 2)
     difference() {
-        beveled_cube([dim, dim, height + box_puzzle_top_inset]);
+        beveled_cube([dim, dim, height + box_puzzle_top_inset], $burr_bevel = 0.5);
         translate([box_puzzle_border, box_puzzle_border, box_puzzle_border])
         cube([
             $burr_scale * 3 + $burr_inset * 2,

--- a/src/main/scad/laszlo-molnar/no-holes-barred/molnar.no-holes-barred.scad
+++ b/src/main/scad/laszlo-molnar/no-holes-barred/molnar.no-holes-barred.scad
@@ -1,19 +1,21 @@
 include <puzzlecad.scad>
 
-box_puzzle_border = 6;
-box_puzzle_top_inset = 1;
-
 $burr_inset = 0.125;
 $burr_bevel = 1;
 $unit_beveled = true;
 $burr_scale = 17;
 
-dim = $burr_scale * 3 + box_puzzle_border * 2 + $burr_inset * 2;
-height = $burr_scale * 3 + box_puzzle_border + $burr_inset;
+box_puzzle_border = 6;
+box_puzzle_top_inset = 1;
+
+// Uncomment one of the following lines to render that component.
 
 *box();
 *pieces();
-*piece_triangle();
+*obstruction();
+
+dim = $burr_scale * 3 + box_puzzle_border * 2 + $burr_inset * 2;
+height = $burr_scale * 3 + box_puzzle_border + $burr_inset;
 
 module box() {
     render(convexity = 2)
@@ -50,7 +52,7 @@ module pieces() {
     ], $plate_width = 160);
 }
 
-module piece_triangle() {
+module obstruction() {
    burr_plate([
        ["x{components={x-,y-,z+y-,z+x-,z-y-,z-x-}}"]
    ]);

--- a/src/main/scad/laszlo-molnar/no-holes-barred/molnar.no-holes-barred.yaml
+++ b/src/main/scad/laszlo-molnar/no-holes-barred/molnar.no-holes-barred.yaml
@@ -1,0 +1,23 @@
+thing-id: 4183029
+name: "No Holes Barred - Packing puzzle by László Molnár"
+tags: [puzzle, 3D_puzzle]
+images: [assembled.jpg, pieces.jpg]
+targets: [box, pieces, obstruction]
+description: |
+    Pack five pieces into an obstructed box.
+    
+    _No Holes Barred_ is one of a series of challenging packing puzzles by László Molnár. It's perhaps the easiest of the series - four of the five pieces are identical - but that definitely doesn't mean "easy"! It's a very clever design and a solid challenge, with a tricky and surprising solution. Highly recommended to both novice and experienced puzzle solvers.
+
+    Yu Chih Chang contributed models and photographs to this listing.
+
+    ### Printing Instructions
+    
+    Print one copy each of `molnar.no-holes-barred.box.stl`, `molnar.no-holes-barred.pieces.stl`, and `molnar.no-holes-barred.obstruction.stl`. Ideally, print the box in one filament color, and print the pieces and obstruction in a different color.
+    
+    Before attempting to solve the puzzle, you will need to permanently attach the obstruction (the small triangular prism) to the box. The obstruction has three alignment pins attached to it, which are designed to fit into the three indentations on the inside of the box in one way only. Put a few drops of superglue (or other adhesive) on the surface of the obstruction, then glue it onto the inside of the box so that it forms a permanent connection. Once the glue sets, you're ready to enjoy the puzzle!
+    
+    ${puzzlecad-boilerplate}
+
+    ${laszlo-molnar-bio}
+
+    Happy puzzling!


### PR DESCRIPTION
@caa1211 I'm adding descriptions for these puzzles in .yaml files. Also a few other minor changes to the .scad files for consistency. Others to follow shortly!