### PR TITLE
Add 2 variables to switch off rendering of main parts / connectors

### DIFF
--- a/src/main/scad/puzzlecad.scad
+++ b/src/main/scad/puzzlecad.scad
@@ -59,6 +59,12 @@ $unit_beveled = false;
 $auto_layout = false;
 $post_rotate = [0, 0, 0];
 
+// Can be set to false to only render connectors
+// or only main parts to have two objects in the slicer.
+// this way, one can e.g. easily have thicker infill for the connectors.
+$render_connectors = true;
+$render_main = true;
+
 // Optional parameters that can be used to increase
 // the amount of beveling on outer edges of burr pieces:
 


### PR DESCRIPTION
$render_connectors and $render_main can be set to false to only render
connectors or only main parts to have two objects in the slicer.
this way, one can e.g. easily have thicker infill for the connectors.

I also have some scripts to automate rendering to STL from puzzlecad files which use this feature.  Don't know where they (or additional documentation on how to use this feature to create sturdier connectors) should best be put.

I have to apply the change in #37 to be able to run puzzlecad on my machine; it's not in this PR though.