### PR TITLE
Added duplication vector for burr_plate() module.

### DIFF
--- a/src/main/scad/puzzlecad/puzzlecad-burr.scad
+++ b/src/main/scad/puzzlecad/puzzlecad-burr.scad
@@ -48,9 +48,11 @@ module burr_piece(burr_spec) {
  * The other arguments should be left as defaults (they're used for recursive calls to burr_plate).
  */
 
-module burr_plate(burr_specs, num_copies = 1) {
+module burr_plate(burr_specs, num_copies = 1, dup = []) {
     
-    burr_infos = [ for (burr_spec = burr_specs) to_burr_info(burr_spec) ];
+    burr_dups = dups(dup, burr_specs);
+    
+    burr_infos = [ for (burr_spec = burr_dups) to_burr_info(burr_spec) ];
     
     layout_burr_infos = $auto_layout ? auto_layout_plate(burr_infos) : burr_infos;
     

--- a/src/main/scad/puzzlecad/puzzlecad-parser.scad
+++ b/src/main/scad/puzzlecad/puzzlecad-parser.scad
@@ -209,3 +209,7 @@ function bit_of(n, exponent) = floor(n / pow(2, exponent)) % 2;
 
 function copies(n, burr) = n == 0 ? [] : concat(copies(n-1, burr), [burr]);
     
+function dups(v, r, i = 0) =
+  i < len(v)
+    ? dups(v, concat(r, [for (x = [0:1:v[i][1] - 1]) r[v[i][0]]]), i + 1)
+    : r;


### PR DESCRIPTION
Perhaps this functionality is already implemented in some form or another, if so, please decline this pull request.

I have encountered a number of puzzles that contain multiple copies of the same piece. Instead of copying the piece specification, it would be nice to have a way to indicate which piece should be duplicated and how many times this should be done. In the example below, we duplicate piece 2 once and piece 3 four times.

    burr_plate([
      ["xxx|.x.", "...|.x."],
      [".xx|xx.", "...|.x."],
      [".x.|xxx", "...|x.."],
      [".x.|xxx"],
      ["x..|xxx"],
      ["x.|xx", "..|.x"]], dup=[[1, 1], [2, 4]]);

I hope you find this useful.