### PR TITLE
Bt2scad --header option

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-puzzlecad is Copyright (c) 2019-2020 Aaron Siegel
+puzzlecad is Copyright (c) 2019-2022 Aaron Siegel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/scripts/admin.py
+++ b/scripts/admin.py
@@ -348,7 +348,11 @@ def bundle_puzzlecad(version, run_tests = True):
 	shutil.copy2('../src/main/scad/dist/half-hour-example.scad', '../out/dist')
 	if (os.path.exists('../out/dist/puzzlecad')):
 		shutil.rmtree('../out/dist/puzzlecad')
-	shutil.copytree('../src/main/scad/puzzlecad', '../out/dist/puzzlecad')
+	shutil.copytree(
+		'../src/main/scad/puzzlecad',
+		'../out/dist/puzzlecad',
+		ignore = shutil.ignore_patterns('.*')		# Ignore .DS_Store and such cruft
+	)
 	
 	print('Creating archive ...')
 	dist_files = [ os.path.relpath(file, '../out/dist') for file in glob('../out/dist/*') ]

--- a/scripts/mit-license-header.txt
+++ b/scripts/mit-license-header.txt
@@ -10,10 +10,10 @@
   Puzzlecad code repository:
   https://github.com/aaron-siegel/puzzlecad
 
-  puzzlecad is (c) 2019-2020 Aaron Siegel and is distributed under
+  puzzlecad is (c) 2019-2022 Aaron Siegel and is distributed under
   the MIT license. This means you may use or modify puzzlecad for any
   purposes, including commercial purposes, provided that you include
-  the attribution "puzzlecad is (c) 2019-2020 Aaron Siegel" in any
+  the attribution "puzzlecad is (c) 2019-2022 Aaron Siegel" in any
   distributions or derivatives of puzzlecad, along with a copy of
   the MIT license.
 

--- a/src/main/java/org/puzzlecad/Arguments.java
+++ b/src/main/java/org/puzzlecad/Arguments.java
@@ -66,6 +66,7 @@ public class Arguments {
 
                     if (header == null && i + 1 < args.length) {
                         header = args[i+1];
+                        i++;
                     } else {
                         throw new InvalidCliException();
                     }

--- a/src/main/java/org/puzzlecad/Arguments.java
+++ b/src/main/java/org/puzzlecad/Arguments.java
@@ -36,9 +36,10 @@ public class Arguments {
 
     int[] filterByColor;
     String filename;
+    String header;
     boolean stdout;
 
-    public Arguments(String[] args) throws Exception {
+    public Arguments(String[] args) {
 
         for (int i = 0; i < args.length; i++) {
 
@@ -60,6 +61,14 @@ public class Arguments {
                 } else if (args[i].equals("--stdout")) {
 
                     stdout = true;
+
+                } else if (args[i].equals("--header")) {
+
+                    if (header == null && i + 1 < args.length) {
+                        header = args[i+1];
+                    } else {
+                        throw new InvalidCliException();
+                    }
 
                 } else {
 

--- a/src/main/java/org/puzzlecad/Arguments.java
+++ b/src/main/java/org/puzzlecad/Arguments.java
@@ -10,10 +10,10 @@
   Puzzlecad code repository:
   https://github.com/aaron-siegel/puzzlecad
 
-  puzzlecad is (c) 2019-2020 Aaron Siegel and is distributed under
+  puzzlecad is (c) 2019-2022 Aaron Siegel and is distributed under
   the MIT license. This means you may use or modify puzzlecad for any
   purposes, including commercial purposes, provided that you include
-  the attribution "puzzlecad is (c) 2019-2020 Aaron Siegel" in any
+  the attribution "puzzlecad is (c) 2019-2022 Aaron Siegel" in any
   distributions or derivatives of puzzlecad, along with a copy of
   the MIT license.
 

--- a/src/main/java/org/puzzlecad/XmpuzzleFile.java
+++ b/src/main/java/org/puzzlecad/XmpuzzleFile.java
@@ -10,10 +10,10 @@
   Puzzlecad code repository:
   https://github.com/aaron-siegel/puzzlecad
 
-  puzzlecad is (c) 2019-2020 Aaron Siegel and is distributed under
+  puzzlecad is (c) 2019-2022 Aaron Siegel and is distributed under
   the MIT license. This means you may use or modify puzzlecad for any
   purposes, including commercial purposes, provided that you include
-  the attribution "puzzlecad is (c) 2019-2020 Aaron Siegel" in any
+  the attribution "puzzlecad is (c) 2019-2022 Aaron Siegel" in any
   distributions or derivatives of puzzlecad, along with a copy of
   the MIT license.
 

--- a/src/main/java/org/puzzlecad/XmpuzzlePiece.java
+++ b/src/main/java/org/puzzlecad/XmpuzzlePiece.java
@@ -10,10 +10,10 @@
   Puzzlecad code repository:
   https://github.com/aaron-siegel/puzzlecad
 
-  puzzlecad is (c) 2019-2020 Aaron Siegel and is distributed under
+  puzzlecad is (c) 2019-2022 Aaron Siegel and is distributed under
   the MIT license. This means you may use or modify puzzlecad for any
   purposes, including commercial purposes, provided that you include
-  the attribution "puzzlecad is (c) 2019-2020 Aaron Siegel" in any
+  the attribution "puzzlecad is (c) 2019-2022 Aaron Siegel" in any
   distributions or derivatives of puzzlecad, along with a copy of
   the MIT license.
 

--- a/src/main/java/org/puzzlecad/XmpuzzleToScad.java
+++ b/src/main/java/org/puzzlecad/XmpuzzleToScad.java
@@ -32,8 +32,7 @@
 
 package org.puzzlecad;
 
-import java.io.File;
-import java.io.PrintWriter;
+import java.io.*;
 
 import static org.puzzlecad.XmpuzzleFile.GRID_TYPE_RECTILINEAR;
 
@@ -80,14 +79,25 @@ public class XmpuzzleToScad {
         out.println("// You can freely edit this file to make changes to the model structure or parameters.");
         out.println();
 
-        out.println("require_puzzlecad_version(\"2.0\");");
-        out.println();
-        if (file.gridType == GRID_TYPE_RECTILINEAR) {
-            out.println("$burr_scale = " + defaultScale() + ";");
-            out.println("$auto_layout = true;");
+        if (arguments.header == null) {
+            // Generate a header
+            out.println("require_puzzlecad_version(\"2.0\");");
+            out.println();
+            if (file.gridType == GRID_TYPE_RECTILINEAR) {
+                out.println("$burr_scale = " + defaultScale() + ";");
+                out.println("$auto_layout = true;");
+            } else {
+                out.println("$burr_scale = 27;");
+            }
         } else {
-            out.println("$burr_scale = 27;");
+            BufferedReader reader = new BufferedReader(new FileReader(arguments.header));
+            String line;
+            while ((line = reader.readLine()) != null) {
+                out.println(line);
+            }
+            reader.close();
         }
+
         out.println();
 
         out.println("burr_plate([");

--- a/src/main/java/org/puzzlecad/XmpuzzleToScad.java
+++ b/src/main/java/org/puzzlecad/XmpuzzleToScad.java
@@ -10,10 +10,10 @@
   Puzzlecad code repository:
   https://github.com/aaron-siegel/puzzlecad
 
-  puzzlecad is (c) 2019-2020 Aaron Siegel and is distributed under
+  puzzlecad is (c) 2019-2022 Aaron Siegel and is distributed under
   the MIT license. This means you may use or modify puzzlecad for any
   purposes, including commercial purposes, provided that you include
-  the attribution "puzzlecad is (c) 2019-2020 Aaron Siegel" in any
+  the attribution "puzzlecad is (c) 2019-2022 Aaron Siegel" in any
   distributions or derivatives of puzzlecad, along with a copy of
   the MIT license.
 

--- a/src/main/java/org/puzzlecad/XmpuzzleVoxel.java
+++ b/src/main/java/org/puzzlecad/XmpuzzleVoxel.java
@@ -10,10 +10,10 @@
   Puzzlecad code repository:
   https://github.com/aaron-siegel/puzzlecad
 
-  puzzlecad is (c) 2019-2020 Aaron Siegel and is distributed under
+  puzzlecad is (c) 2019-2022 Aaron Siegel and is distributed under
   the MIT license. This means you may use or modify puzzlecad for any
   purposes, including commercial purposes, provided that you include
-  the attribution "puzzlecad is (c) 2019-2020 Aaron Siegel" in any
+  the attribution "puzzlecad is (c) 2019-2022 Aaron Siegel" in any
   distributions or derivatives of puzzlecad, along with a copy of
   the MIT license.
 

--- a/src/main/scad/puzzlecad.scad
+++ b/src/main/scad/puzzlecad.scad
@@ -10,10 +10,10 @@
   Puzzlecad code repository:
   https://github.com/aaron-siegel/puzzlecad
 
-  puzzlecad is (c) 2019-2020 Aaron Siegel and is distributed under
+  puzzlecad is (c) 2019-2022 Aaron Siegel and is distributed under
   the MIT license. This means you may use or modify puzzlecad for any
   purposes, including commercial purposes, provided that you include
-  the attribution "puzzlecad is (c) 2019-2020 Aaron Siegel" in any
+  the attribution "puzzlecad is (c) 2019-2022 Aaron Siegel" in any
   distributions or derivatives of puzzlecad, along with a copy of
   the MIT license.
 


### PR DESCRIPTION
Adds a --header option to bt2scad, so that .scad headers/parameters can be specified in a file rather than auto-generated.